### PR TITLE
Fix typo in zram tutorial

### DIFF
--- a/community-tutorials/zram-tutorial/01-en.md
+++ b/community-tutorials/zram-tutorial/01-en.md
@@ -15,7 +15,7 @@ available_languages: en
 
 # Introduction
 
-Especially on systems with little RAM, it can happen from time to time that the available memory becomes scarce and the system start to use swap memory. As swap memory is typically located on the hard drive, it is relatively slow compared to RAM and thus may impact the system's performance.
+Especially on systems with little RAM, it can happen from time to time that the available memory becomes scarce and the system starts to use swap memory. As swap memory is typically located on the hard drive, it is relatively slow compared to RAM and thus may impact the system's performance.
 
 A remedy is provided by a technology integrated in the Linux kernel called zRam. It creates a compressing block device directly in the computer's RAM. The kernel first occupies the available RAM and then tries to compress parts of it into zRam. It effectively only moves data within the RAM, which is magnitudes faster than swapping to disk. This technique, therefore, allows more data to be accommodated in memory. Practically, this results in the system not having to swap to a slower hard disk as quickly. The price is a slightly increased processor load which usually has a much smaller impact than swapping to disk.
 


### PR DESCRIPTION
Just a grammar typo in "system starts"

Hi KB19,

if you want to incorporate this typo fix directly into your PR because netcup is slow in reviewing an pull requests ;-)

🦆